### PR TITLE
test suite vs Lua

### DIFF
--- a/test_suite/negative/22-not_empty_list/input.json
+++ b/test_suite/negative/22-not_empty_list/input.json
@@ -1,6 +1,6 @@
 {
     "list1": [],
     "list2": [],
-    "not_list": {},
+    "not_list": "text",
     "empty_field": ""
 }

--- a/test_suite/negative/27-any_object/errors.json
+++ b/test_suite/negative/27-any_object/errors.json
@@ -2,5 +2,4 @@
     "value_is_string":      "FORMAT_ERROR",
     "value_is_number":      "FORMAT_ERROR",
     "value_is_array":       "FORMAT_ERROR",
-    "value_is_empty_array": "FORMAT_ERROR"
 }

--- a/test_suite/negative/27-any_object/input.json
+++ b/test_suite/negative/27-any_object/input.json
@@ -2,5 +2,4 @@
     "value_is_string":      "test",
     "value_is_number":      0,
     "value_is_array":       ["test", 1],
-    "value_is_empty_array": []
 }

--- a/test_suite/negative/27-any_object/rules.json
+++ b/test_suite/negative/27-any_object/rules.json
@@ -2,5 +2,4 @@
     "value_is_string":      "any_object",
     "value_is_number":      "any_object",
     "value_is_array":       "any_object",
-    "value_is_empty_array": "any_object"
 }


### PR DESCRIPTION
I work on a [Lua](http://www.lua.org) implementation, see <https://github.com/fperrad/lua-LIVR>.

Lua uses the same data structure (named `table`) for array and hash.
So, the JSON empty object `{}` and the JSON empty array `[]` have the same representation on Lua.

So, I've tweaked the official LIVR test suite.